### PR TITLE
fixed class in display template (fix colours)

### DIFF
--- a/BookmarkDisplayTemplate.tid
+++ b/BookmarkDisplayTemplate.tid
@@ -3,13 +3,12 @@ title: $:/plugins/OokTech/Bookmarks/BookmarkDisplayTemplate
 
 <a
     href={{!!url}}
-    target="_blank"
+    target="_blank" class="tc-tiddlylink-external"
 >
     <$view
         field=title
-    />
-</a>
-- {{!!note}} (<$link
+    /></a>
+ - {{!!note}} (<$link
     to={{!!title}}
 >
     Open Tiddler


### PR DESCRIPTION
added  class="tc-tiddlylink-external" to make the links format in accordance with the colour pallet of TW 

delted a "space" and added it later, to make the space non-hyperlinked

see https://github.com/OokTech/TW5-Bookmarks/issues/2